### PR TITLE
✨ Feat : 메인페이지 기능 구현 (항목별 분류, 타입 확장, 캐러셀 적용)

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -18,8 +18,8 @@ export default function RootLayout({
     <html lang="en">
       <body className="w-full">
         <Header />
-        {children}
         <AuthModalProvider />
+        {children}
         <Footer />
       </body>
     </html>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,14 +1,31 @@
-import { createClient } from "@/lib/supabase/server";
-import { cookies } from "next/headers";
+import { createClient } from "@/lib/supabase/client";
 import MainSmallBanner from "@/components/main/MainSmallBanner";
 import Image from "next/image";
 import PostcardSectionList from "@/components/main/PostcardSectionList";
+import { getAllPosts } from "@/services/post";
 
 export default async function Home() {
   const supabase = await createClient();
 
+  const posts = (await getAllPosts({})) ?? [];
+
+  const popularPosts = [...posts].sort(
+    (a, b) => (b.like_count ?? 0) - (a.like_count ?? 0),
+  );
+
+  // 마감일이 가까운 순 (오름차순)
+  const closingSoonPosts = [...posts].sort(
+    (a, b) => new Date(a.end_date).getTime() - new Date(b.end_date).getTime(),
+  );
+
+  // 등록일이 최근인 순 (내림차순)
+  const newPosts = [...posts].sort(
+    (a, b) =>
+      new Date(b.created_at).getTime() - new Date(a.created_at).getTime(),
+  );
+
   return (
-    <div className="max-w-[1200px] mx-auto mt-30">
+    <div className="max-w-[1120px] mx-auto mt-30 overflow-hidden">
       <section className="mb-20">
         <div className="mb-5">
           <Image
@@ -20,7 +37,7 @@ export default async function Home() {
         </div>
         <div className="flex flex-wrap gap-5">
           <MainSmallBanner
-            linkHerf="/"
+            linkHref="/study"
             title="스터디 보러가기"
             bannerCaption="모집 중인 스터디를 찾아보세요"
             backgroundColor="bg-secondary-2"
@@ -35,7 +52,7 @@ export default async function Home() {
             bannerHeight={133}
           />
           <MainSmallBanner
-            linkHerf="/"
+            linkHref="/project"
             title="프로젝트 보러가기"
             bannerCaption="모집 중인 프로젝트를 찾아보세요"
             backgroundColor="bg-secondary-1"
@@ -50,7 +67,7 @@ export default async function Home() {
             bannerHeight={133}
           />
           <MainSmallBanner
-            linkHerf="/"
+            linkHref="/service"
             title="서비스 보러가기"
             bannerCaption="홍보 중인 서비스를 찾아보세요"
             backgroundColor="bg-primary-5"
@@ -68,16 +85,19 @@ export default async function Home() {
       </section>
       <section className="mb-20">
         <PostcardSectionList
+          posts={popularPosts}
           title="Hot 인기있는 프로젝트"
           badgeType="success"
           badgeText="인기있는"
         />
         <PostcardSectionList
+          posts={closingSoonPosts}
           title="Now 곧 마감되는 프로젝트"
           badgeType="danger"
           badgeText="마감직전"
         />
         <PostcardSectionList
+          posts={newPosts}
           title="New 새로운 프로젝트"
           badgeType="warning"
           badgeText="새로운"

--- a/src/components/common/CarouselButtom.tsx
+++ b/src/components/common/CarouselButtom.tsx
@@ -1,0 +1,24 @@
+"use client";
+import { useCarousel } from "@/components/ui/carousel";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+
+export const CustomCarouselButtons = () => {
+  const { scrollPrev, scrollNext } = useCarousel();
+
+  return (
+    <div className="flex gap-2">
+      <button
+        onClick={scrollPrev}
+        className="text-gray-40 cursor-pointer hover:text-primary-3 transition-colors"
+      >
+        <ChevronLeft size={25} />
+      </button>
+      <button
+        onClick={scrollNext}
+        className="text-gray-40 cursor-pointer hover:text-primary-3 transition-colors"
+      >
+        <ChevronRight size={25} />
+      </button>
+    </div>
+  );
+};

--- a/src/components/common/Postcard.tsx
+++ b/src/components/common/Postcard.tsx
@@ -3,25 +3,29 @@ import { AvatarImage } from "@radix-ui/react-avatar";
 import { Avatar } from "../ui/avatar";
 import { Bookmark, ThumbsUp } from "lucide-react";
 import { Badge } from "../ui/badge";
-import { SKILLS } from "@/constants/skills";
 import SkillLogo from "./SkillLogo";
-import { POSITION } from "@/constants/position";
 import { formatDate } from "@/lib/formatDate";
 import { toggleBookmark, toggleLike } from "@/services/like_and_bookmark";
 import { useState } from "react";
 import { useAuthModalStore } from "@/store/authModalStore";
+import { getSkillByStack } from "@/lib/getSkillByStack";
+import Link from "next/link";
 interface PostcardProps {
   postId: number;
   content: string;
   usernickName: string;
-  created_at: number;
+  end_date: string;
+  tecthStack: string[];
+  position: string[];
 }
 
 const Postcard = ({
   postId,
   content,
   usernickName,
-  created_at,
+  end_date,
+  tecthStack,
+  position,
 }: PostcardProps) => {
   const { openModal } = useAuthModalStore();
   const [isLiked, setIsLiked] = useState(false);
@@ -30,10 +34,10 @@ const Postcard = ({
   const MAX_VISIBLE_POSITION = 2;
 
   const remainingSkillsCount = () =>
-    Math.max(SKILLS.length - MAX_VISIBLE_SKILLS, 0);
+    Math.max(tecthStack.length - MAX_VISIBLE_SKILLS, 0);
 
   const remainingPositionCount = () =>
-    Math.max(POSITION.length - MAX_VISIBLE_POSITION, 0);
+    Math.max(position.length - MAX_VISIBLE_POSITION, 0);
 
   const handleLToggleike = async (postId: number) => {
     const result = await toggleLike(postId);
@@ -66,72 +70,85 @@ const Postcard = ({
   };
 
   return (
-    <div className="w-full max-w-[258px] h-[295px] p-6 border rounded-lg bg-white input-shadow duration-300 cursor-pointer card-shadow">
-      <div className="flex justify-between mb-[15px]">
-        <span className="flex items-center gap-[10px]">
-          <span>
-            <Avatar className="group size-[33px] cursor-pointer">
-              <AvatarImage
-                src="/images/default-user-image.svg"
-                className="object-cover"
-                alt="유저프로필이미지"
+    <Link href={`/posts/${postId}`}>
+      <div className="w-full max-w-[258px] h-[295px] p-6 border rounded-lg bg-white input-shadow duration-300 cursor-pointer card-shadow">
+        <div className="flex justify-between mb-[15px]">
+          <span className="flex items-center gap-[10px]">
+            <span>
+              <Avatar className="group size-[33px] cursor-pointer">
+                <AvatarImage
+                  src="/images/default-user-image.svg"
+                  className="object-cover"
+                  alt="유저프로필이미지"
+                />
+              </Avatar>
+            </span>
+            <span className="body-b">{usernickName}</span>
+          </span>
+          <span className="flex items-center gap-[6px]">
+            <span>
+              <ThumbsUp
+                onClick={() => handleLToggleike(postId)}
+                size={24}
+                className={
+                  isLiked ? "text-blue-500 fill-current" : "text-gray-50"
+                }
               />
-            </Avatar>
+            </span>
+            <span>
+              <Bookmark
+                onClick={() => handleToggleBookmark(postId)}
+                size={24}
+                className={
+                  isBookmarked ? "text-blue-500 fill-current" : "text-gray-50"
+                }
+              />
+            </span>
           </span>
-          <span className="body-b">{usernickName}</span>
-        </span>
-        <span className="flex items-center gap-[6px]">
-          <span>
-            <ThumbsUp
-              onClick={() => handleLToggleike(postId)}
-              size={24}
-              className={
-                isLiked ? "text-blue-500 fill-current" : "text-gray-50"
-              }
-            />
-          </span>
-          <span>
-            <Bookmark
-              onClick={() => handleToggleBookmark(postId)}
-              size={24}
-              className={
-                isBookmarked ? "text-blue-500 fill-current" : "text-gray-50"
-              }
-            />
-          </span>
+        </div>
+        <div className="flex flex-col justify-between h-[170px]">
+          <div className="flex-1 mb-4 overflow-hidden">
+            <p className="body-large-r line-clamp-3">{content}</p>
+          </div>
+          <div className="mb-[10px]">
+            <ul className="flex items-center gap-1 mb-[13px]">
+              {tecthStack.slice(0, 5).map((stack) => {
+                const matchedSkill = getSkillByStack(stack);
+                if (!matchedSkill) return null;
+                return (
+                  <li key={stack}>
+                    <SkillLogo
+                      name={matchedSkill.name}
+                      skill={matchedSkill.skill}
+                    />
+                  </li>
+                );
+              })}
+              {remainingSkillsCount() > 0 && (
+                <li className="w-7 h-7 rounded-full flex items-center justify-center border border-solid border-primary-3 caption-b text-primary-3 bg-white">
+                  +{remainingSkillsCount()}
+                </li>
+              )}
+            </ul>
+            <ul className="flex gap-[5px] mb-[10px]">
+              {position.slice(0, 2).map((position) => (
+                <li key={position}>
+                  <Badge variant="position">{position}</Badge>
+                </li>
+              ))}
+              {remainingPositionCount() > 0 && (
+                <li className="py-[3px] px-2.5 bg-gray-5 text-primary-2 rounded-md caption-b">
+                  +{remainingPositionCount()}
+                </li>
+              )}
+            </ul>
+          </div>
+        </div>
+        <span className="caption-r text-gray-50">
+          마감일 | <span>{formatDate(end_date)}</span>
         </span>
       </div>
-      <div>
-        <div className="mb-4">
-          <p className="body-large-r line-clamp-3">{content}</p>
-        </div>
-        <div className="mb-[10px]">
-          <ul className="flex items-center gap-1 mb-[13px]">
-            {SKILLS.slice(0, 5).map((skill) => (
-              <li key={skill.skill}>
-                <SkillLogo name={skill.name} skill={skill.skill} />
-              </li>
-            ))}
-            <li className="w-7 h-7 rounded-full flex items-center justify-center border border-solid border-primary-3 caption-b text-primary-3 bg-white">
-              +{remainingSkillsCount()}
-            </li>
-          </ul>
-          <ul className="flex gap-[5px] mb-[10px]">
-            {POSITION.slice(0, 2).map((position) => (
-              <li key={position}>
-                <Badge variant="position">{position}</Badge>
-              </li>
-            ))}
-            <li className="py-[3px] px-2.5 bg-gray-5 text-primary-2 rounded-md caption-b">
-              +{remainingPositionCount()}
-            </li>
-          </ul>
-        </div>
-      </div>
-      <span className="caption-r text-gray-50">
-        마감일 | <span>{formatDate(created_at)}</span>
-      </span>
-    </div>
+    </Link>
   );
 };
 export default Postcard;

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -50,9 +50,9 @@ const Header = () => {
 
   return (
     <header className="fixed top-0 left-0 z-20 w-full h-[80px] py-[21px] px-10 bg-white">
-      <nav className="max-w-[1200px] mx-auto flex items-center justify-between">
+      <nav className="max-w-[1120px] mx-auto flex items-center justify-between">
         <div className="flex flex-1 mr-[250px]">
-          <Link href="/" className="px-[22px] mr-[100px]">
+          <Link href="/" className="mr-[100px]">
             <Image
               src="/images/logo.svg"
               alt="mergi 로고"

--- a/src/components/main/MainSmallBanner.tsx
+++ b/src/components/main/MainSmallBanner.tsx
@@ -2,7 +2,7 @@ import Image from "next/image";
 import Link from "next/link";
 
 interface MainSmallBannerProps {
-  linkHerf: string;
+  linkHref: string;
   title: string;
   bannerCaption: string;
   backgroundColor: string;
@@ -18,7 +18,7 @@ interface MainSmallBannerProps {
 }
 
 const MainSmallBanner = ({
-  linkHerf,
+  linkHref,
   title,
   bannerCaption,
   backgroundColor,
@@ -33,7 +33,7 @@ const MainSmallBanner = ({
   bannerHeight,
 }: MainSmallBannerProps) => {
   return (
-    <Link href={linkHerf}>
+    <Link href={linkHref}>
       <div
         className={`relative w-90 h-[205px] p-[30px] ${backgroundColor} rounded-md`}
       >

--- a/src/components/main/PostcardSectionList.tsx
+++ b/src/components/main/PostcardSectionList.tsx
@@ -1,66 +1,59 @@
+import { PostRpcRow } from "@/types/post";
 import Postcard from "../common/Postcard";
 import StatusBadge from "../common/StatusBadge";
+import * as React from "react";
+import {
+  Carousel,
+  CarouselContent,
+  CarouselItem,
+} from "@/components/ui/carousel";
+import { CustomCarouselButtons } from "../common/CarouselButtom";
 
 interface PostcardSectionList {
   title: string;
   badgeType: "success" | "warning" | "danger" | "done";
   badgeText: string;
+  posts: PostRpcRow[];
 }
-
-const postList = [
-  {
-    id: 1,
-    usernickName: "파파고",
-    content:
-      "멋진프로젝트를 만들어봅시다 주제는 파파고 api를 이용한 어쩌고입니다 모집합니다모집합니다모집합니다모집...",
-    created_at: 20250813,
-  },
-  {
-    id: 2,
-    usernickName: "파파고",
-    content:
-      "멋진프로젝트를 만들어봅시다 주제는 파파고 api를 이용한 어쩌고입니다 모집합니다모집합니다모집합니다모집...",
-    created_at: 20250813,
-  },
-  {
-    id: 3,
-    usernickName: "파파고",
-    content:
-      "멋진프로젝트를 만들어봅시다 주제는 파파고 api를 이용한 어쩌고입니다 모집합니다모집합니다모집합니다모집...",
-    created_at: 20250813,
-  },
-  {
-    id: 4,
-    usernickName: "파파고",
-    content:
-      "멋진프로젝트를 만들어봅시다 주제는 파파고 api를 이용한 어쩌고입니다 모집합니다모집합니다모집합니다모집...",
-    created_at: 20250813,
-  },
-];
 
 const PostcardSectionList = ({
   title,
   badgeType,
   badgeText,
+  posts,
 }: PostcardSectionList) => {
   return (
-    <article className="mb-15">
-      <h2 className="flex items-center  gap-[10px] mb-6 h1-b text-gray-90">
-        {title}
-        <StatusBadge badgeType={badgeType} badgeText={badgeText} />
-      </h2>
-      <div className="flex gap-[30px]">
-        {postList.map((item) => (
-          <Postcard
-            key={item.id}
-            postId={item.id}
-            usernickName={item.usernickName}
-            content={item.content}
-            created_at={item.created_at}
-          />
-        ))}
-      </div>
-    </article>
+    <Carousel
+      className="w-full overflow-hidden"
+      opts={{ loop: true, align: "start" }}
+    >
+      <article className="mb-15">
+        <div className="flex items-center justify-between mb-6">
+          <h2 className="flex items-center gap-[10px] h1-b text-gray-90">
+            {title}
+            <StatusBadge badgeType={badgeType} badgeText={badgeText} />
+          </h2>
+          <div className="flex gap-2">
+            <CustomCarouselButtons />
+          </div>
+        </div>
+        <CarouselContent className="ml-0">
+          {posts.map((post) => (
+            <CarouselItem key={post.id} className="pr-6 pl-0 basis-[280px]">
+              <Postcard
+                key={post.id}
+                postId={post.id}
+                usernickName={post.name ?? "알 수 없음"}
+                content={post.content}
+                end_date={post.end_date}
+                tecthStack={post.techStack ?? []}
+                position={post.position ?? []}
+              />
+            </CarouselItem>
+          ))}
+        </CarouselContent>
+      </article>
+    </Carousel>
   );
 };
 

--- a/src/components/ui/carousel.tsx
+++ b/src/components/ui/carousel.tsx
@@ -1,45 +1,45 @@
-"use client"
+"use client";
 
-import * as React from "react"
+import * as React from "react";
 import useEmblaCarousel, {
   type UseEmblaCarouselType,
-} from "embla-carousel-react"
-import { ArrowLeft, ArrowRight } from "lucide-react"
+} from "embla-carousel-react";
+import { ArrowLeft, ArrowRight } from "lucide-react";
 
-import { cn } from "@/lib/utils"
-import { Button } from "@/components/ui/button"
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
 
-type CarouselApi = UseEmblaCarouselType[1]
-type UseCarouselParameters = Parameters<typeof useEmblaCarousel>
-type CarouselOptions = UseCarouselParameters[0]
-type CarouselPlugin = UseCarouselParameters[1]
+type CarouselApi = UseEmblaCarouselType[1];
+type UseCarouselParameters = Parameters<typeof useEmblaCarousel>;
+type CarouselOptions = UseCarouselParameters[0];
+type CarouselPlugin = UseCarouselParameters[1];
 
 type CarouselProps = {
-  opts?: CarouselOptions
-  plugins?: CarouselPlugin
-  orientation?: "horizontal" | "vertical"
-  setApi?: (api: CarouselApi) => void
-}
+  opts?: CarouselOptions;
+  plugins?: CarouselPlugin;
+  orientation?: "horizontal" | "vertical";
+  setApi?: (api: CarouselApi) => void;
+};
 
 type CarouselContextProps = {
-  carouselRef: ReturnType<typeof useEmblaCarousel>[0]
-  api: ReturnType<typeof useEmblaCarousel>[1]
-  scrollPrev: () => void
-  scrollNext: () => void
-  canScrollPrev: boolean
-  canScrollNext: boolean
-} & CarouselProps
+  carouselRef: ReturnType<typeof useEmblaCarousel>[0];
+  api: ReturnType<typeof useEmblaCarousel>[1];
+  scrollPrev: () => void;
+  scrollNext: () => void;
+  canScrollPrev: boolean;
+  canScrollNext: boolean;
+} & CarouselProps;
 
-const CarouselContext = React.createContext<CarouselContextProps | null>(null)
+const CarouselContext = React.createContext<CarouselContextProps | null>(null);
 
 function useCarousel() {
-  const context = React.useContext(CarouselContext)
+  const context = React.useContext(CarouselContext);
 
   if (!context) {
-    throw new Error("useCarousel must be used within a <Carousel />")
+    throw new Error("useCarousel must be used within a <Carousel />");
   }
 
-  return context
+  return context;
 }
 
 function Carousel({
@@ -56,53 +56,53 @@ function Carousel({
       ...opts,
       axis: orientation === "horizontal" ? "x" : "y",
     },
-    plugins
-  )
-  const [canScrollPrev, setCanScrollPrev] = React.useState(false)
-  const [canScrollNext, setCanScrollNext] = React.useState(false)
+    plugins,
+  );
+  const [canScrollPrev, setCanScrollPrev] = React.useState(false);
+  const [canScrollNext, setCanScrollNext] = React.useState(false);
 
   const onSelect = React.useCallback((api: CarouselApi) => {
-    if (!api) return
-    setCanScrollPrev(api.canScrollPrev())
-    setCanScrollNext(api.canScrollNext())
-  }, [])
+    if (!api) return;
+    setCanScrollPrev(api.canScrollPrev());
+    setCanScrollNext(api.canScrollNext());
+  }, []);
 
   const scrollPrev = React.useCallback(() => {
-    api?.scrollPrev()
-  }, [api])
+    api?.scrollPrev();
+  }, [api]);
 
   const scrollNext = React.useCallback(() => {
-    api?.scrollNext()
-  }, [api])
+    api?.scrollNext();
+  }, [api]);
 
   const handleKeyDown = React.useCallback(
     (event: React.KeyboardEvent<HTMLDivElement>) => {
       if (event.key === "ArrowLeft") {
-        event.preventDefault()
-        scrollPrev()
+        event.preventDefault();
+        scrollPrev();
       } else if (event.key === "ArrowRight") {
-        event.preventDefault()
-        scrollNext()
+        event.preventDefault();
+        scrollNext();
       }
     },
-    [scrollPrev, scrollNext]
-  )
+    [scrollPrev, scrollNext],
+  );
 
   React.useEffect(() => {
-    if (!api || !setApi) return
-    setApi(api)
-  }, [api, setApi])
+    if (!api || !setApi) return;
+    setApi(api);
+  }, [api, setApi]);
 
   React.useEffect(() => {
-    if (!api) return
-    onSelect(api)
-    api.on("reInit", onSelect)
-    api.on("select", onSelect)
+    if (!api) return;
+    onSelect(api);
+    api.on("reInit", onSelect);
+    api.on("select", onSelect);
 
     return () => {
-      api?.off("select", onSelect)
-    }
-  }, [api, onSelect])
+      api?.off("select", onSelect);
+    };
+  }, [api, onSelect]);
 
   return (
     <CarouselContext.Provider
@@ -129,11 +129,11 @@ function Carousel({
         {children}
       </div>
     </CarouselContext.Provider>
-  )
+  );
 }
 
 function CarouselContent({ className, ...props }: React.ComponentProps<"div">) {
-  const { carouselRef, orientation } = useCarousel()
+  const { carouselRef, orientation } = useCarousel();
 
   return (
     <div
@@ -145,16 +145,16 @@ function CarouselContent({ className, ...props }: React.ComponentProps<"div">) {
         className={cn(
           "flex",
           orientation === "horizontal" ? "-ml-4" : "-mt-4 flex-col",
-          className
+          className,
         )}
         {...props}
       />
     </div>
-  )
+  );
 }
 
 function CarouselItem({ className, ...props }: React.ComponentProps<"div">) {
-  const { orientation } = useCarousel()
+  const { orientation } = useCarousel();
 
   return (
     <div
@@ -164,11 +164,11 @@ function CarouselItem({ className, ...props }: React.ComponentProps<"div">) {
       className={cn(
         "min-w-0 shrink-0 grow-0 basis-full",
         orientation === "horizontal" ? "pl-4" : "pt-4",
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
 function CarouselPrevious({
@@ -177,7 +177,7 @@ function CarouselPrevious({
   size = "icon",
   ...props
 }: React.ComponentProps<typeof Button>) {
-  const { orientation, scrollPrev, canScrollPrev } = useCarousel()
+  const { orientation, scrollPrev, canScrollPrev } = useCarousel();
 
   return (
     <Button
@@ -189,7 +189,7 @@ function CarouselPrevious({
         orientation === "horizontal"
           ? "top-1/2 -left-12 -translate-y-1/2"
           : "-top-12 left-1/2 -translate-x-1/2 rotate-90",
-        className
+        className,
       )}
       disabled={!canScrollPrev}
       onClick={scrollPrev}
@@ -198,7 +198,7 @@ function CarouselPrevious({
       <ArrowLeft />
       <span className="sr-only">Previous slide</span>
     </Button>
-  )
+  );
 }
 
 function CarouselNext({
@@ -207,7 +207,7 @@ function CarouselNext({
   size = "icon",
   ...props
 }: React.ComponentProps<typeof Button>) {
-  const { orientation, scrollNext, canScrollNext } = useCarousel()
+  const { orientation, scrollNext, canScrollNext } = useCarousel();
 
   return (
     <Button
@@ -219,7 +219,7 @@ function CarouselNext({
         orientation === "horizontal"
           ? "top-1/2 -right-12 -translate-y-1/2"
           : "-bottom-12 left-1/2 -translate-x-1/2 rotate-90",
-        className
+        className,
       )}
       disabled={!canScrollNext}
       onClick={scrollNext}
@@ -228,7 +228,7 @@ function CarouselNext({
       <ArrowRight />
       <span className="sr-only">Next slide</span>
     </Button>
-  )
+  );
 }
 
 export {
@@ -238,4 +238,5 @@ export {
   CarouselItem,
   CarouselPrevious,
   CarouselNext,
-}
+  useCarousel,
+};

--- a/src/lib/getSkillByStack.ts
+++ b/src/lib/getSkillByStack.ts
@@ -1,0 +1,7 @@
+import { SKILLS } from "@/constants/skills";
+
+export const getSkillByStack = (stackName: string) => {
+  const normalized = stackName.toLowerCase().replace(/[.\s-]/g, "");
+
+  return SKILLS.find((s) => s.skill.replace(/_/g, "") === normalized);
+};

--- a/src/types/post.ts
+++ b/src/types/post.ts
@@ -23,6 +23,8 @@ export type PostPaginationResult = {
 export type PostRpcRow = PostEntity & {
   position?: string[];
   techStack?: string[];
+  name?: string;
+  like_count?: number;
 };
 
 /** 게시물 상세 타입 */


### PR DESCRIPTION
## 💡**작업 내용**

### ✨ 작업 내용

- sort를 사용하여 게시글을 좋아요순, 최근 기준 마감일순, 최근 기준 등록일순으로 분류했습니다.
- 각 항목별 UI에 캐러셀 적용했습니다.


### 💻 그 외

- 포스트 카드에 포지션 및 스킬 뱃지 표시 및 카운트 기능 추가하여 UI에 보일 수 있도록 했습니다.

## ⚙️**수정 사항**
- RootLayout children 순서 변경 및 Header 스타일 수정했습니다.