### PR TITLE
🔄 Refactor: 온보딩 API 호출을 user.ts 서비스 함수로 교체

### DIFF
--- a/src/app/onboarding/step1/page.tsx
+++ b/src/app/onboarding/step1/page.tsx
@@ -6,6 +6,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { createClient } from "@/lib/supabase/client";
+import { checkDuplicateNickname } from "@/services/user";
 import { useOnboardingStore } from "@/store/onboardingStore";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
@@ -27,14 +28,9 @@ const Step1 = () => {
       return;
     }
 
-    const supbase = createClient();
-    const { data } = await supbase
-      .from("user_list")
-      .select("id")
-      .eq("name", nickname)
-      .maybeSingle();
+    const isDuplicate = await checkDuplicateNickname(nickname);
 
-    if (data) {
+    if (isDuplicate) {
       setNicknameStatus("duplicate");
     } else {
       setNicknameStatus("valid");

--- a/src/app/onboarding/step2/page.tsx
+++ b/src/app/onboarding/step2/page.tsx
@@ -6,6 +6,7 @@ import ProfilePromptModal from "@/components/onboarding/ProfilePromptModal";
 import { Button } from "@/components/ui/button";
 import { POSITION_SKILLS } from "@/constants/position";
 import { createClient } from "@/lib/supabase/client";
+import { postUserInfoOnboard } from "@/services/user";
 import { useOnboardingStore } from "@/store/onboardingStore";
 import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
@@ -44,56 +45,26 @@ const Step2 = () => {
 
     if (!user) return;
 
-    const {
-      data: { session },
-    } = await supabase.auth.getSession();
+    const userPositions = positions.map((pos) => ({
+      position: pos,
+      stacks: selectedSkills.filter((skill) =>
+        POSITION_SKILLS[pos]?.includes(skill),
+      ),
+    }));
 
-    const { data: newUser, error } = await supabase
-      .from("user_list")
-      .insert({
+    const result = await postUserInfoOnboard(
+      {
         user_id: user.id,
         name: nickname,
         short_introduce: introduce,
         created_at: new Date().toISOString(),
-      })
-      .select("id")
-      .single();
+      },
+      userPositions,
+    );
 
-    if (error || !newUser) {
-      console.error("프로필 생성 실패", error?.message);
+    if (!result) {
+      console.error("온보딩 저장 실패");
       return;
-    }
-
-    for (const pos of positions) {
-      const { data: newPos, error: posError } = await supabase
-        .from("user_list_positions")
-        .insert({
-          profile_id: newUser.id,
-          position: pos,
-          created_at: new Date().toISOString(),
-        })
-        .select("id")
-        .single();
-
-      if (posError || !newPos) {
-        console.error(`포지션 저장 실패 (${pos})`, posError?.message);
-        continue;
-      }
-
-      const skillsForPos = selectedSkills.filter((skill) =>
-        POSITION_SKILLS[pos]?.includes(skill),
-      );
-
-      const { error: stackError } = await supabase
-        .from("user_list_stacks")
-        .insert({
-          position_id: newPos.id,
-          stacks: skillsForPos,
-          created_at: new Date().toISOString(),
-        });
-
-      if (stackError)
-        console.error(`스킬 저장 실패 (${pos})`, stackError.message);
     }
 
     setShowProfilePromptModal(true);


### PR DESCRIPTION
## 💡**작업 내용**

### ✨ 작업 내용

- 온보딩 Step1에서 Supabase 직접 호출하던 로직을 제거했습니다.
- 기존에 구현되어 있던 postUserInfoOnboard API를 활용하도록 수정했습니다.
- 온보딩 데이터 전송 흐름을 API 기반으로 일원화했습니다.

### 💻 그 외

- 동일한 기능을 중복 구현하는 대신 공통 API를 활용하여 코드 일관성과 유지보수성을 높이기 위해서 변경했습니다.

## ⚙️**수정 사항**
- Step1.tsx의 handleNextClick 로직 변경했습니다.
- Supabase 직접 호출 제거 → postUserInfoOnboard API 호출로 교체했습니다.
- 스토어 저장 및 라우팅 로직은 기존과 동일하게 유지했습니다.