### PR TITLE
🔄 Refactor :  마이페이지 API 호출을 user.ts와  post.ts 서비스 함수로 교체

### DIFF
--- a/src/app/mypage/components/FavoritesTab.tsx
+++ b/src/app/mypage/components/FavoritesTab.tsx
@@ -1,19 +1,9 @@
 import Postcard from "@/components/common/Postcard";
 import { Button } from "@/components/ui/button";
+import { PostRpcRow } from "@/types/post";
 import Link from "next/link";
-
 interface FavoritesTabProps {
-  favoritePost: {
-    id: number;
-    content: string;
-    end_date: string;
-    recruit_field: string;
-    author: string;
-    authorName: string;
-    post_positions: { position: string }[];
-    post_stacks: { stack: string }[];
-    // user_list: { name: string }[];
-  }[];
+  favoritePost: (PostRpcRow & { name?: string })[];
 }
 
 const FavoritesTab = ({ favoritePost }: FavoritesTabProps) => {
@@ -22,17 +12,16 @@ const FavoritesTab = ({ favoritePost }: FavoritesTabProps) => {
     <div className="px-4">
       {hasFavoritePost ? (
         <section>
-          <ul className="flex flex-wrap justify-between gap-4 py-4">
-            {favoritePost.map((postItem) => (
-              <li key={postItem.id} className="mb-8 last:mb-0">
+          <ul className="flex flex-wrap gap-4 py-4">
+            {favoritePost.map((post) => (
+              <li key={post.id} className="mb-8 last:mb-0">
                 <Postcard
-                  key={postItem.id}
-                  postId={postItem.id}
-                  usernickName={postItem.authorName}
-                  content={postItem.content}
-                  end_date={postItem.end_date}
-                  techStack={postItem.post_stacks.map((s) => s.stack)}
-                  position={postItem.recruit_field.split(", ")}
+                  postId={post.id}
+                  usernickName={post.name ?? "알 수 없음"}
+                  content={post.content}
+                  end_date={post.end_date}
+                  techStack={post.techStack ?? []}
+                  position={post.position ?? []}
                 />
               </li>
             ))}

--- a/src/app/mypage/components/MypageView.tsx
+++ b/src/app/mypage/components/MypageView.tsx
@@ -11,38 +11,13 @@ import MyPostsTab from "./MypostsTab";
 import MyApplicationsTab from "./MyApplicationsTab";
 import FavoritesTab from "./FavoritesTab";
 import { useState } from "react";
+import { UserInfo } from "@/types/user";
+import { PostRpcRow } from "@/types/post";
 
 interface MypageViewProps {
-  profile: {
-    name: string | undefined;
-    short_introduce: string;
-    long_introduce: string | undefined;
-    link: string[] | undefined;
-    user_list_positions: {
-      position: string;
-      user_list_stacks: { stacks: string[] }[];
-    }[];
-  } | null;
-  post: {
-    id: number;
-    content: string;
-    usernickName: string;
-    end_date: string;
-    recruit_field: string;
-    post_positions: { position: string }[];
-    post_stacks: { stack: string }[];
-  }[];
-  favoritePost: {
-    id: number;
-    content: string;
-    end_date: string;
-    recruit_field: string;
-    author: string;
-    authorName: string;
-    post_positions: { position: string }[];
-    post_stacks: { stack: string }[];
-    // user_list: { name: string }[];
-  }[];
+  profile: UserInfo | null;
+  post: PostRpcRow[];
+  favoritePost: (PostRpcRow & { author: string })[];
 }
 const tabMenuItems = [
   { label: "내 정보", value: "profileTab" },
@@ -86,7 +61,9 @@ const MypageView = ({ profile, post, favoritePost }: MypageViewProps) => {
           <PositionBadge
             className="flex gap-[15px] mb-[10px]"
             positions={
-              profile?.user_list_positions?.map((p) => p.position) ?? []
+              profile?.positions
+                ?.map((p) => p.position)
+                .filter((p): p is string => p !== null) ?? []
             }
           />
         </div>
@@ -104,9 +81,9 @@ const MypageView = ({ profile, post, favoritePost }: MypageViewProps) => {
             {selectedTab === "profileTab" && (
               <div className="mt-6 p-4 px-10">
                 <ProfileTab
-                  long_introduce={profile?.long_introduce}
-                  link={profile?.link}
-                  positionWithStacks={profile?.user_list_positions ?? []}
+                  long_introduce={profile?.long_introduce || ""}
+                  link={profile?.link || []}
+                  positionWithStacks={profile?.positions ?? []}
                 />
               </div>
             )}

--- a/src/app/mypage/components/MypostsTab.tsx
+++ b/src/app/mypage/components/MypostsTab.tsx
@@ -1,18 +1,11 @@
 import Postcard from "@/components/common/Postcard";
 import { Button } from "@/components/ui/button";
-import { id } from "date-fns/locale";
+import { PostRpcRow } from "@/types/post";
 import Link from "next/link";
 
 interface MyPostsTabProps {
-  post: {
-    id: number;
-    content: string;
-    end_date: string;
-    recruit_field: string;
-    post_positions: { position: string }[];
-    post_stacks: { stack: string }[];
-  }[];
-  userNickName: string | undefined;
+  post: PostRpcRow[];
+  userNickName: string | null | undefined;
 }
 
 const MyPostsTab = ({ post, userNickName }: MyPostsTabProps) => {
@@ -29,8 +22,8 @@ const MyPostsTab = ({ post, userNickName }: MyPostsTabProps) => {
               usernickName={userNickName ?? "알 수 없음"}
               content={post.content}
               end_date={post.end_date}
-              techStack={post.post_stacks.map((s) => s.stack)}
-              position={post.recruit_field.split(", ")}
+              techStack={post.techStack ?? []}
+              position={post.position ?? []}
             />
           ))}
         </section>

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -1,6 +1,8 @@
 import { createClient } from "@/lib/supabase/server";
 import MypageView from "./components/MypageView";
 import { redirect } from "next/navigation";
+import { getUserInfoToUserId } from "@/services/user";
+import { getPostsByUser, getBookmarkPostsByUser } from "@/services/post";
 
 const Page = async () => {
   const supabase = await createClient();
@@ -12,78 +14,16 @@ const Page = async () => {
     redirect("/login");
   }
 
-  console.log("user:", user);
-  console.log("user.id:", user.id);
-  const { data: profile, error } = await supabase
-    .from("user_list")
-    .select(
-      `
-    *,
-    user_list_positions (
-      id,
-      position,
-      user_list_stacks (
-        stacks
-      )
-    )
-  `,
-    )
-    .eq("user_id", user.id)
-    .maybeSingle();
-
-  const { data: post, error: postError } = await supabase
-    .from("post")
-    .select(
-      `
-    *,
-    post_positions (
-      position
-    ),
-    post_stacks (
-      stack
-    )
-  `,
-    )
-    .eq("author", user.id);
-
-  const { data: bookmarks, error: bookmarkError } = await supabase
-    .from("post_bookmark")
-    .select(
-      `
-    post:post_id (
-      id,
-      content,
-      end_date,
-      recruit_field,
-      author,
-      post_positions ( position ),
-      post_stacks ( stack )
-    )
-  `,
-    )
-    .eq("user_id", user.id);
-
-  const favoritePostRaw = bookmarks?.flatMap((b) => b.post) ?? [];
-
-  const authorIds = [...new Set(favoritePostRaw.map((p) => p.author))];
-  const { data: authors } = authorIds.length
-    ? await supabase
-        .from("user_list")
-        .select("user_id, name")
-        .in("user_id", authorIds)
-    : { data: [] };
-
-  const favoritePost = favoritePostRaw.map((p) => ({
-    ...p,
-    authorName:
-      authors?.find((a) => a.user_id === p.author)?.name ?? "알 수 없음",
-  }));
+  const profile = await getUserInfoToUserId(user.id, supabase);
+  const postResult = await getPostsByUser(user.id, {}, 1, 100, supabase);
+  const bookmarkResult = await getBookmarkPostsByUser({}, 1, 100, supabase);
+  console.log("bookmarkResult:", JSON.stringify(bookmarkResult, null, 2));
 
   return (
     <MypageView
       profile={profile}
-      post={post ?? []}
-      favoritePost={favoritePost}
+      post={postResult?.posts ?? []}
+      favoritePost={bookmarkResult?.posts ?? []}
     />
   );
 };

--- a/src/components/profile/ProfileTab.tsx
+++ b/src/components/profile/ProfileTab.tsx
@@ -9,8 +9,8 @@ interface ProfileTabProps {
   long_introduce: string | undefined;
   link: string[] | undefined;
   positionWithStacks: {
-    position: string;
-    user_list_stacks: { stacks: string[] }[];
+    position: string | null;
+    stacks: string[];
   }[];
 }
 
@@ -69,11 +69,11 @@ const ProfileTab = ({
       <section>
         <h3 className="mb-[10px] h3-b text-gray-80">포지션 & 스킬</h3>
         <div className="p-7 rounded-lg bg-secondary-3 input-shadow">
-          {positionWithStacks.map(({ position, user_list_stacks }) => (
+          {positionWithStacks.map(({ position, stacks }) => (
             <ul key={position} className="mb-7">
               <h4 className="body-large-m text-gray-80 mb-3">{position}</h4>
               <li className="flex gap-4">
-                {(user_list_stacks[0]?.stacks ?? []).map((skill) => (
+                {(stacks ?? []).map((skill) => (
                   <SkillBadge key={skill} name={skill} skill={skill} />
                 ))}
               </li>

--- a/src/services/post.ts
+++ b/src/services/post.ts
@@ -1,5 +1,5 @@
-import { createClient } from "@/lib/supabase/client";
-import { PostEntity, UserListEntity } from "@/types/type";
+import { SupabaseClient } from "@supabase/supabase-js";
+import { createClient as createBrowserClient } from "@/lib/supabase/client";
 import { getPostComments } from "./comments";
 import {
   PostDetails,
@@ -8,7 +8,8 @@ import {
   PostRpcRow,
 } from "@/types/post";
 
-const supabase = createClient();
+const resolveClient = (client?: SupabaseClient): SupabaseClient =>
+  client ?? createBrowserClient();
 
 /**
  * 전체 게시물 목록 조회
@@ -18,7 +19,10 @@ const supabase = createClient();
 export const getAllPosts = async (
   filters: PostFilters,
   size: number = 10,
+  client?: SupabaseClient,
 ): Promise<PostRpcRow[] | null> => {
+  const supabase = resolveClient(client);
+
   try {
     const { data, error } = await supabase.rpc("get_all_posts", {
       filters,
@@ -47,7 +51,10 @@ export const getAllPostsWithPagination = async (
   filters: PostFilters,
   page: number = 1,
   page_size: number = 12,
+  client?: SupabaseClient,
 ): Promise<PostPaginationResult> => {
+  const supabase = resolveClient(client);
+
   try {
     const { data, error } = await supabase.rpc(
       "get_filtered_posts_with_pagination",
@@ -76,7 +83,10 @@ export const getMyApplyPosts = async (
   filters: PostFilters,
   page: number = 1,
   page_size: number = 4,
+  client?: SupabaseClient,
 ): Promise<PostPaginationResult | null> => {
+  const supabase = resolveClient(client);
+
   try {
     const { data, error } = await supabase.rpc("get_my_apply_posts", {
       filters,
@@ -106,7 +116,10 @@ export const getBookmarkPostsByUser = async (
   filters: PostFilters,
   page: number,
   page_size: number,
+  client?: SupabaseClient,
 ): Promise<PostPaginationResult | null> => {
+  const supabase = resolveClient(client);
+
   const { data, error } = await supabase.rpc(
     "get_user_bookmarks_with_pagination",
     { filters, page, page_size },
@@ -132,7 +145,10 @@ export const getPostsByUser = async (
   filters: PostFilters,
   page: number,
   page_size: number,
+  client?: SupabaseClient,
 ): Promise<PostPaginationResult | null> => {
+  const supabase = resolveClient(client);
+
   const { data, error } = await supabase.rpc(
     "get_post_by_user_with_pagination",
     { filters, page, page_size, user_id },
@@ -153,7 +169,10 @@ export const getPostsByUser = async (
  */
 export const getPostDetails = async (
   postId: number,
+  client?: SupabaseClient,
 ): Promise<PostDetails | null> => {
+  const supabase = resolveClient(client);
+
   try {
     const { data: post, error: postError } = await supabase
       .from("post")
@@ -167,8 +186,8 @@ export const getPostDetails = async (
     }
 
     const [position, techStack, comments] = await Promise.all([
-      getPostPositions(postId),
-      getPostTechStacks(postId),
+      getPostPositions(postId, supabase),
+      getPostTechStacks(postId, supabase),
       getPostComments(postId),
     ]);
 
@@ -194,7 +213,12 @@ export const getPostDetails = async (
  * 특정 게시물의 포지션 목록 조회
  * @param postId - 조회할 게시물 id
  */
-export const getPostPositions = async (postId: number): Promise<string[]> => {
+export const getPostPositions = async (
+  postId: number,
+  client?: SupabaseClient,
+): Promise<string[]> => {
+  const supabase = resolveClient(client);
+
   const { data, error } = await supabase
     .from("post_positions")
     .select("position")
@@ -213,7 +237,12 @@ export const getPostPositions = async (postId: number): Promise<string[]> => {
  * 특정 게시물의 기술스택 목록 조회
  * @param postId - 조회할 게시물 id
  */
-export const getPostTechStacks = async (postId: number): Promise<string[]> => {
+export const getPostTechStacks = async (
+  postId: number,
+  client?: SupabaseClient,
+): Promise<string[]> => {
+  const supabase = resolveClient(client);
+
   const { data, error } = await supabase
     .from("post_stacks")
     .select("stack")

--- a/src/services/user.ts
+++ b/src/services/user.ts
@@ -1,4 +1,5 @@
-import { createClient } from "@/lib/supabase/client";
+import { SupabaseClient } from "@supabase/supabase-js";
+import { createClient as createBrowserClient } from "@/lib/supabase/client";
 import { getUserLoggedIn } from "./auth";
 import {
   UserListEntity,
@@ -8,9 +9,16 @@ import {
   UserListPositionInsert,
   UserListStackEntity,
 } from "@/types/type";
-import { PositionInput, PositionWithStacks, ProfilePostError, ProfileUpdateError, UserInfo } from "@/types/user";
+import {
+  PositionInput,
+  PositionWithStacks,
+  ProfilePostError,
+  ProfileUpdateError,
+  UserInfo,
+} from "@/types/user";
 
-const supabase = createClient();
+const resolveClient = (client?: SupabaseClient): SupabaseClient =>
+  client ?? createBrowserClient();
 
 /**
  * 온보드 데이터 전송 API
@@ -20,8 +28,11 @@ const supabase = createClient();
 export const postUserInfoOnboard = async (
   userProfile: UserListInsert,
   userPositions: PositionInput[],
+  client?: SupabaseClient,
 ): Promise<UserInfo | undefined> => {
-  const userList = await _postUserProfile(userProfile);
+  const supabase = resolveClient(client);
+
+  const userList = await _postUserProfile(supabase, userProfile);
 
   if (typeof userList === "string") {
     console.error(`온보딩 전송 중단. 에러명: ${userList}`);
@@ -34,6 +45,7 @@ export const postUserInfoOnboard = async (
   await Promise.all(
     userPositions.map(async (positionInput) => {
       const userPosition = await _postUserPositions(
+        supabase,
         {
           position: positionInput.position,
           created_at: new Date().toISOString(),
@@ -43,6 +55,7 @@ export const postUserInfoOnboard = async (
       if (!userPosition) return;
 
       const userStack = await _postUserStacks(
+        supabase,
         {
           stacks: positionInput.stacks,
           created_at: new Date().toISOString(),
@@ -64,6 +77,7 @@ export const postUserInfoOnboard = async (
 
 // 유저 프로필 POST
 const _postUserProfile = async (
+  supabase: SupabaseClient,
   insertObject: UserListInsert,
 ): Promise<UserListEntity | ProfilePostError | null> => {
   const { data, error } = await supabase
@@ -94,6 +108,7 @@ const _postUserProfile = async (
 
 // 유저 포지션 POST
 const _postUserPositions = async (
+  supabase: SupabaseClient,
   insertObject: UserListPositionInsert,
   profile_id: number,
 ): Promise<UserListPositionEntity | null> => {
@@ -113,6 +128,7 @@ const _postUserPositions = async (
 
 // 유저 스택 POST
 const _postUserStacks = async (
+  supabase: SupabaseClient,
   insertObject: { stacks: string[]; created_at: string },
   position_id: number,
 ): Promise<UserListStackEntity | null> => {
@@ -140,14 +156,18 @@ const _postUserStacks = async (
  * 로그인된 유저 정보 조회
  * @returns 유저 프로필 + 포지션/스택 정보
  */
-export const getUserInfo = async (): Promise<UserInfo | null> => {
+export const getUserInfo = async (
+  client?: SupabaseClient,
+): Promise<UserInfo | null> => {
+  const supabase = resolveClient(client);
+
   const authData = await getUserLoggedIn();
   if (!authData?.id) return null;
 
-  const profile = await _getUserProfile(authData.id);
+  const profile = await _getUserProfile(supabase, authData.id);
   if (!profile) return null;
 
-  const rawPositions = await _getUserPositions(profile.id);
+  const rawPositions = await _getUserPositions(supabase, profile.id);
   if (!rawPositions) return null;
 
   const positions = await Promise.all(
@@ -155,7 +175,7 @@ export const getUserInfo = async (): Promise<UserInfo | null> => {
       async (pos): Promise<PositionWithStacks> => ({
         id: pos.id,
         position: pos.position,
-        stacks: await _getUserStacks(pos.id),
+        stacks: await _getUserStacks(supabase, pos.id),
       }),
     ),
   );
@@ -166,15 +186,19 @@ export const getUserInfo = async (): Promise<UserInfo | null> => {
 /**
  * 특정 유저 정보 조회 (user_id 기반)
  * @param user_id - 조회할 유저의 auth user_id
+ * @param client - 서버 컴포넌트에서 호출 시 "@/lib/supabase/server" 클라이언트를 넘길 것
  * @returns 유저 프로필 + 포지션/스택 정보
  */
 export const getUserInfoToUserId = async (
   user_id: string,
+  client?: SupabaseClient,
 ): Promise<UserInfo | null> => {
-  const profile = await _getUserProfile(user_id);
+  const supabase = resolveClient(client);
+
+  const profile = await _getUserProfile(supabase, user_id);
   if (!profile) return null;
 
-  const rawPositions = await _getUserPositions(profile.id);
+  const rawPositions = await _getUserPositions(supabase, profile.id);
   if (!rawPositions) return null;
 
   const positions = await Promise.all(
@@ -182,7 +206,7 @@ export const getUserInfoToUserId = async (
       async (pos): Promise<PositionWithStacks> => ({
         id: pos.id,
         position: pos.position,
-        stacks: await _getUserStacks(pos.id),
+        stacks: await _getUserStacks(supabase, pos.id),
       }),
     ),
   );
@@ -192,13 +216,14 @@ export const getUserInfoToUserId = async (
 
 // 유저 프로필 GET
 const _getUserProfile = async (
+  supabase: SupabaseClient,
   user_id: string,
 ): Promise<UserListEntity | null> => {
   const { data, error } = await supabase
     .from("user_list")
     .select()
     .eq("user_id", user_id)
-    .single();
+    .maybeSingle();
 
   if (error) {
     console.error(error);
@@ -210,6 +235,7 @@ const _getUserProfile = async (
 
 // 유저 포지션 GET
 const _getUserPositions = async (
+  supabase: SupabaseClient,
   profile_id: number,
 ): Promise<Pick<UserListPositionEntity, "id" | "position">[] | null> => {
   const { data, error } = await supabase
@@ -226,12 +252,15 @@ const _getUserPositions = async (
 };
 
 // 유저 스택 GET
-const _getUserStacks = async (position_id: number): Promise<string[]> => {
+const _getUserStacks = async (
+  supabase: SupabaseClient,
+  position_id: number,
+): Promise<string[]> => {
   const { data, error } = await supabase
     .from("user_list_stacks")
     .select("stacks")
     .eq("position_id", position_id)
-    .single();
+    .maybeSingle();
 
   if (error) {
     console.error(error);
@@ -251,11 +280,18 @@ const _getUserStacks = async (position_id: number): Promise<string[]> => {
 export const putUserInfo = async (
   updatingUserProfile: UserListUpdate,
   updatingUserPositions: PositionInput[],
+  client?: SupabaseClient,
 ): Promise<UserInfo | undefined> => {
+  const supabase = resolveClient(client);
+
   const user = await getUserLoggedIn();
   if (!user?.id) return;
 
-  const userList = await _putUserProfile(updatingUserProfile, user.id);
+  const userList = await _putUserProfile(
+    supabase,
+    updatingUserProfile,
+    user.id,
+  );
 
   // typeof string → 에러 코드이므로 조기 반환
   // 이후 userList는 UserListEntity로 타입 확정
@@ -264,12 +300,13 @@ export const putUserInfo = async (
     return;
   }
 
-  await _deleteUserPositions(userList.id);
+  await _deleteUserPositions(supabase, userList.id);
 
   const positionsArr: PositionWithStacks[] = [];
 
   for (const positionInput of updatingUserPositions) {
     const updatedPosition = await _postUserPositions(
+      supabase,
       {
         position: positionInput.position,
         created_at: new Date().toISOString(),
@@ -279,6 +316,7 @@ export const putUserInfo = async (
     if (!updatedPosition) continue;
 
     const updatedStacks = await _postUserStacks(
+      supabase,
       {
         stacks: positionInput.stacks,
         created_at: new Date().toISOString(),
@@ -299,6 +337,7 @@ export const putUserInfo = async (
 
 // 유저 프로필 PUT
 const _putUserProfile = async (
+  supabase: SupabaseClient,
   updateObject: UserListUpdate,
   user_id: string,
 ): Promise<UserListEntity | ProfileUpdateError> => {
@@ -323,7 +362,10 @@ const _putUserProfile = async (
 };
 
 // 유저 포지션 DELETE
-const _deleteUserPositions = async (profile_id: number): Promise<void> => {
+const _deleteUserPositions = async (
+  supabase: SupabaseClient,
+  profile_id: number,
+): Promise<void> => {
   const { error } = await supabase
     .from("user_list_positions")
     .delete()
@@ -340,7 +382,10 @@ const _deleteUserPositions = async (profile_id: number): Promise<void> => {
  */
 export const checkDuplicateNickname = async (
   nickname: string,
+  client?: SupabaseClient,
 ): Promise<boolean> => {
+  const supabase = resolveClient(client);
+
   const { data, error } = await supabase.rpc("check_username_duplicate", {
     user_name: nickname,
   });


### PR DESCRIPTION
## 💡**작업 내용**

### ✨ 작업 내용

- 마이페이지에서 supabase를 직접 호출하던 유저 프로필/게시물/북마크 조회 로직을 services/user.ts, services/post.ts의 API 함수로 교체했습니다.
- user.ts, post.ts 전체 함수에 client?: SupabaseClient 옵셔널 인자를 추가해 서버/클라이언트 컴포넌트 겸용으로 리팩터링했습니다.
- FavoritesTab에서 작성자 이름 필드명 불일치(authorName → name) 수정했습니다.

### 💻 그 외

- MypageView, MyPostsTab, FavoritesTab, PositionBadge 등에서 API 응답 타입 변경했습니다.

## ⚙️**수정 사항**
